### PR TITLE
Revert "Bump connexion[swagger-ui] from 2.4.0 to 2.6.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ setuptools >= 21.0.0
 gunicorn==20.0.4
 flask-marshmallow==0.10.1
 flask-cors==3.0.8
-connexion[swagger-ui]==2.6.0
+connexion[swagger-ui]==2.4.0


### PR DESCRIPTION
Reverts kevinmmartins/python-flask-connexion-example-openapi3#14